### PR TITLE
Remove tag/people features and switch to o3

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
   // Stream the response to the client with improved error handling and performance
   try {
     const result = await streamText({
-      model: openai('gpt-4o-mini'),
+      model: openai('o3'),
       messages: fullMessages,
       temperature: 0.7, // Add some creativity but keep responses focused
       maxTokens: 3000, // Limit response length for faster streaming

--- a/src/app/api/summaries/route.ts
+++ b/src/app/api/summaries/route.ts
@@ -202,7 +202,7 @@ export async function POST(request: Request) {
       console.log('Calling AI model to generate summary...');
       // Call the AI model to generate the summary
       const result = await generateText({
-        model: openai('gpt-4o-mini'),
+        model: openai('o3'),
         messages: [
           {
             role: 'system',
@@ -220,26 +220,21 @@ export async function POST(request: Request) {
       const fullSummary = result.text || '';
       console.log('Full AI response:', fullSummary);
 
-      // Parse the response to extract summary, tags, and people
-      const { summary, tags, people } = parseAiResponse(fullSummary);
+      // Parse the response to get the summary text
+      const { summary } = parseAiResponse(fullSummary);
 
       console.log('Extracted Summary:', summary);
-      console.log('Extracted Tags:', tags);
-      console.log('Extracted People:', people);
 
-      // Update the record with the generated summary, tags, and people
+      // Update the record with the generated summary
       console.log('Updating record with generated summary...');
       console.log('Summary ID:', summaryId);
-      console.log('Summary:', summary);
-      console.log('Tags:', tags);
-      console.log('People:', people);
 
       const { error: updateError } = await dbClient
         .from('summaries')
         .update({
           summary: summary,
-          tags: tags,
-          featured_names: people,
+          tags: [],
+          featured_names: [],
           status: 'completed',
         })
         .eq('id', summaryId);
@@ -255,8 +250,8 @@ export async function POST(request: Request) {
         id: summaryId,
         title: videoTitle,
         summary: summary,
-        tags: tags,
-        featured_names: people,
+        tags: [],
+        featured_names: [],
         publisher_id: channelId,
         publisher_name: name,
         content_created_at: publishedAt,

--- a/src/app/api/summaries/route.ts
+++ b/src/app/api/summaries/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
     const { data, error } = await dbClient
       .from('summaries')
       .select(
-        'id, title, summary, tags, featured_names, publisher_name, content_created_at, duration_in_seconds, transcript_raw, content_id',
+        'id, title, summary, publisher_name, content_created_at, duration_in_seconds, transcript_raw, content_id',
       )
       .eq('content_id', videoId)
       .single();

--- a/src/app/channels/[channelId]/page.tsx
+++ b/src/app/channels/[channelId]/page.tsx
@@ -15,8 +15,6 @@ interface Summary {
   publisher_id: string;
   summary: string;
   content_id: string;
-  tags?: string[];
-  featured_names?: string[];
 }
 
 interface ChannelDetails {
@@ -162,8 +160,6 @@ export default async function ChannelPage({ params }: ChannelPageProps) {
                   channelName={summary.publisher_name}
                   channelId={summary.publisher_id}
                   summary={summary.summary}
-                  tags={summary.tags || []}
-                  peopleMentioned={summary.featured_names || []}
                   videoId={summary.content_id}
                 />
               ))}

--- a/src/app/chat/[videoId]/page.tsx
+++ b/src/app/chat/[videoId]/page.tsx
@@ -15,8 +15,6 @@ interface SummaryData {
   id: string;
   title: string;
   summary: string;
-  tags?: string[];
-  featured_names?: string[];
   publisher_name: string;
   publisher_id: string;
   content_created_at: string;

--- a/src/app/chat/[videoId]/page.tsx
+++ b/src/app/chat/[videoId]/page.tsx
@@ -15,8 +15,8 @@ interface SummaryData {
   id: string;
   title: string;
   summary: string;
-  tags: string[];
-  featured_names: string[];
+  tags?: string[];
+  featured_names?: string[];
   publisher_name: string;
   publisher_id: string;
   content_created_at: string;
@@ -175,8 +175,6 @@ export default function ChatPage() {
           id: data.id,
           title: data.title || 'Untitled Video',
           summary: data.summary || 'No summary available',
-          tags: Array.isArray(data.tags) ? data.tags : [],
-          featured_names: Array.isArray(data.featured_names) ? data.featured_names : [],
           publisher_name: data.publisher_name || 'Unknown Channel',
           publisher_id: data.publisher_id || '',
           content_created_at: data.content_created_at || new Date().toISOString(),
@@ -281,8 +279,6 @@ export default function ChatPage() {
             channelName={summaryData.publisher_name}
             channelId={summaryData.publisher_id}
             summary={summaryData.summary}
-            tags={summaryData.tags}
-            peopleMentioned={summaryData.featured_names}
             videoId={summaryData.videoId}
           />
         )}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -16,8 +16,6 @@ interface Summary {
   publisher_id: string;
   summary: string;
   content_id: string;
-  tags?: string[];
-  featured_names?: string[];
 }
 
 // Helper function to safely validate a summary object
@@ -249,8 +247,6 @@ export default async function HistoryPage({ searchParams }: HistoryPageProps) {
                   channelName={summary.publisher_name}
                   channelId={summary.publisher_id}
                   summary={summary.summary}
-                  tags={summary.tags || []}
-                  peopleMentioned={summary.featured_names || []}
                   videoId={summary.content_id}
                 />
               ))

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -294,8 +294,6 @@ export default function Home() {
             channelName={summaryData.publisher_name}
             channelId={summaryData.publisher_id}
             summary={summaryData.summary}
-            tags={summaryData.tags}
-            peopleMentioned={summaryData.featured_names}
             videoId={summaryData.videoId || summaryData.content_id || ''}
           />
         </div>
@@ -323,8 +321,6 @@ export default function Home() {
                     channelName={summary.publisher_name}
                     channelId={summary.publisher_id}
                     summary={summary.summary}
-                    tags={summary.tags}
-                    peopleMentioned={summary.featured_names}
                     videoId={summary.videoId || summary.content_id || ''}
                   />
                 ))}

--- a/src/components/AnonymousHistoryLoader.tsx
+++ b/src/components/AnonymousHistoryLoader.tsx
@@ -14,8 +14,6 @@ interface Summary {
   publisher_id: string;
   summary: string;
   content_id: string;
-  tags?: string[];
-  featured_names?: string[];
 }
 
 // Helper function to safely validate a summary object
@@ -126,8 +124,6 @@ export default function AnonymousHistoryLoader() {
           channelName={summary.publisher_name}
           channelId={summary.publisher_id}
           summary={summary.summary}
-          tags={summary.tags || []}
-          peopleMentioned={summary.featured_names || []}
           videoId={summary.content_id}
         />
       ))}

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -41,8 +41,6 @@ interface SummaryCardProps {
   channelName: string;
   channelId: string;
   summary: string;
-  tags?: string[];
-  peopleMentioned?: string[];
   videoId: string;
   isSubscribed?: boolean;
 }

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -1,11 +1,11 @@
-// src/components/SummaryCard.tsx - Component for displaying video summary information with tags and channel details
+// src/components/SummaryCard.tsx - Component for displaying video summary information with channel details
 'use client';
 
 import React, { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-import { Calendar, Tag, Users, ExternalLink, FileText, MessageCircle, BookOpen } from 'lucide-react';
+import { Calendar, ExternalLink, FileText, MessageCircle, BookOpen } from 'lucide-react';
 import { SubscribeButton } from '@/components/SubscribeButton';
 import ReactMarkdown from 'react-markdown';
 import { GlowButton } from '@/components/ui/glow-button';
@@ -41,8 +41,8 @@ interface SummaryCardProps {
   channelName: string;
   channelId: string;
   summary: string;
-  tags: string[];
-  peopleMentioned: string[];
+  tags?: string[];
+  peopleMentioned?: string[];
   videoId: string;
   isSubscribed?: boolean;
 }
@@ -303,8 +303,6 @@ export default function SummaryCard({
   channelName,
   channelId,
   summary,
-  tags = [],
-  peopleMentioned = [],
   videoId,
   isSubscribed = false,
 }: SummaryCardProps) {
@@ -376,46 +374,6 @@ export default function SummaryCard({
 
         {/* Footer section */}
         <div className='flex flex-wrap items-start justify-between gap-4'>
-          <div className='space-y-3 w-full md:w-auto'>
-            {/* Tags */}
-            {tags.length > 0 && (
-              <div className='flex flex-wrap items-center gap-2'>
-                <span className='flex items-center text-sm dark:text-gray-400 text-gray-600 mr-1'>
-                  <Tag size={14} className='mr-1' />
-                  Topics:
-                </span>
-                <div className='flex flex-wrap gap-1.5'>
-                  {tags.map((tag, index) => (
-                    <span
-                      key={index}
-                      className='text-xs dark:bg-blue-900/30 bg-blue-100 dark:text-blue-300 text-blue-700 px-2.5 py-1 rounded-md border dark:border-blue-800/50 border-blue-200 font-medium transition-colors duration-200 dark:hover:bg-blue-800/40 hover:bg-blue-200 dark:hover:border-blue-700/50 hover:border-blue-300 cursor-default'>
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* People mentioned */}
-            {peopleMentioned.length > 0 && (
-              <div className='flex flex-wrap items-center gap-2'>
-                <span className='flex items-center text-sm dark:text-gray-400 text-gray-600 mr-1'>
-                  <Users size={14} className='mr-1' />
-                  People:
-                </span>
-                <div className='flex flex-wrap gap-1.5'>
-                  {peopleMentioned.map((person, index) => (
-                    <span
-                      key={index}
-                      className='text-xs dark:bg-purple-900/30 bg-purple-100 dark:text-purple-300 text-purple-700 px-2.5 py-1 rounded-md border dark:border-purple-800/50 border-purple-200 font-medium transition-colors duration-200 dark:hover:bg-purple-800/40 hover:bg-purple-200 dark:hover:border-purple-700/50 hover:border-purple-300 cursor-default'>
-                      {person}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-
           {/* Action buttons - Redesigned layout */}
           <div className='w-full md:w-auto mt-4 md:mt-0 pt-4 md:pt-0 border-t md:border-0 dark:border-gray-800 border-gray-200 md:ml-auto'>
             <div className='flex flex-col sm:flex-row gap-2'>

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,58 +1,8 @@
 // src/lib/prompts.ts - Collection of prompt templates used for AI generation tasks
-export const SUMMARY_PROMPT = `You are an expert content summarizer who creates structured, concise summaries. Analyze the following video content and create a summary that matches the original's tone and style.
+export const SUMMARY_PROMPT = `You are an expert summarizer. Using the transcript below, produce a concise but comprehensive summary capturing all important points. Use markdown paragraphs and bullet points for clarity. Do not reference the transcript or the video. Return only the summary.
 
-OUTPUT FORMAT (STRICTLY FOLLOW THIS):
-Summary:
-* **[Main Point]**: [Clear explanation]
-* **[Main Point]**: [Clear explanation]
-* **[Main Point]**: [Clear explanation]
-* **[Main Point]**: [Clear explanation]
-* **[Main Point]**: [Clear explanation]
-
-[OPTIONAL - Include ONLY if there is a HIGHLY impactful, specific quote that meaningfully represents a key insight. Do NOT include generic statements or routine explanations:]
-> "Direct quote from the content"
-
-Tags: tag1, tag2, tag3, tag4, tag5
-
-People: person1, person2, person3
-
-REQUIREMENTS:
-1. NEVER use phrases like "this video," "the speaker," "in this transcript," etc. Avoid referencing the medium (e.g., 'this video,' 'the speaker').
-2. Match the EXACT tone and language style of the original content.
-3. Each bullet point MUST follow the format: * **Bold main point**: Explanation
-4. Include only bullet points covering the most important insights. Keep it concise.
-5. Include 5-10 relevant lowercase tags separated by commas.
-6. List all people mentioned, separated by commas. If no specific people are mentioned, write "None" in the People section.
-7. QUOTES: Only include quotes that are genuinely impactful, specific, and central to the content's message. If no strong quotes exist, OMIT the quote section entirely. Never fabricate quotes or include generic statements.
-
-GOOD EXAMPLE:
------
-Summary:
-* **AI Risk Management Framework**: The framework provides a comprehensive approach for organizations to address AI risks while promoting innovation.
-* **Four Core Functions**: The framework is built around four functions: govern, map, measure, and manage.
-* **Customizable Implementation**: Organizations can adapt the framework based on their context, use cases, and risk profiles.
-* **Transparency Requirements**: Companies must document AI systems and communicate clearly about their capabilities and limitations.
-* **Continuous Testing**: Regular evaluation of AI systems helps identify and mitigate potential risks and biases.
-
-Tags: ai ethics, risk management, governance, compliance, technology policy, data security
-
-People: Mark Johnson, Sarah Williams, David Chen
------
-
-BAD EXAMPLE:
------
-Summary:
-In this video, the speaker discusses AI risk management. The transcript shows several points about governance and implementation. They talk about four functions and mention transparency.
-
-> "We need to be careful with AI" [BAD - this is too generic and not impactful]
-
-Tags: AI, management, video
-People: Johnson, someone else
------
-
-Now analyze and summarize the following transcript:
-
-Content: {transcript}`;
+Transcript:
+{transcript}`;
 
 // System prompt for Q&A feature to guide LLM responses
 export const QNA_SYSTEM_PROMPT = `

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,5 +1,5 @@
 // src/lib/prompts.ts - Collection of prompt templates used for AI generation tasks
-export const SUMMARY_PROMPT = `You are an expert summarizer. Using the transcript below, produce a concise but comprehensive summary capturing all important points. Use markdown paragraphs and bullet points for clarity. Do not reference the transcript or the video. Return only the summary.
+export const SUMMARY_PROMPT = `You are an expert summarizer. Using the transcript below, craft a clear and complete summary capturing all key points. Format the response in Markdown with paragraphs and bullet points, using **bold** text to highlight important ideas. Do not mention the transcript or the video. Return only the summary.
 
 Transcript:
 {transcript}`;

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,5 +1,5 @@
 // src/lib/prompts.ts - Collection of prompt templates used for AI generation tasks
-export const SUMMARY_PROMPT = `You are an expert summarizer. Using the transcript below, craft a clear and complete summary capturing all key points. Format the response in Markdown with paragraphs and bullet points, using **bold** text to highlight important ideas. Do not mention the transcript or the video. Return only the summary.
+export const SUMMARY_PROMPT = `You are an expert summarizer. Using the transcript below, craft a thorough summary that captures all of the important parts of the video or podcast. Format the response in Markdown with short paragraphs and bullet points, using **bold** text to highlight key ideas. Do not mention the transcript or the video. Return only the summary.
 
 Transcript:
 {transcript}`;

--- a/src/lib/utils/formatSummaryData.ts
+++ b/src/lib/utils/formatSummaryData.ts
@@ -4,8 +4,6 @@ export interface SummaryData {
   id: string;
   title: string;
   summary: string;
-  tags: string[];
-  featured_names: string[];
   publisher_name: string;
   publisher_id: string;
   content_created_at: string;
@@ -24,8 +22,6 @@ export interface RawSummaryData extends Record<string, unknown> {
   id?: string;
   title?: string;
   summary?: string;
-  tags?: string[];
-  featured_names?: string[];
   publisher_name?: string;
   publisher_id?: string;
   content_created_at?: string;
@@ -41,8 +37,6 @@ export function formatSummaryData(item: RawSummaryData): SummaryData {
     id: item.id as string,
     title: (item.title as string) || 'YouTube Video',
     summary: (item.summary as string) || 'No summary available',
-    tags: Array.isArray(item.tags) ? item.tags : [],
-    featured_names: Array.isArray(item.featured_names) ? item.featured_names : [],
     publisher_name: (item.publisher_name as string) || 'Unknown Channel',
     publisher_id: (item.publisher_id as string) || '',
     content_created_at: (item.content_created_at as string) || new Date().toISOString(),

--- a/supabase/functions/send-daily-newsletter/index.ts
+++ b/supabase/functions/send-daily-newsletter/index.ts
@@ -46,8 +46,6 @@ interface Summary {
   summary: string;
   content_created_at: string;
   created_at: string;
-  tags?: string[];
-  featured_names?: string[];
   source_url?: string;
 }
 
@@ -224,32 +222,6 @@ async function sendEmail(data: EmailData): Promise<boolean> {
             .summary-content li {
               margin-bottom: 8px;
             }
-            .people-section {
-              margin-top: 16px;
-              text-align: left;
-              position: relative;
-              z-index: 1;
-              padding-top: 16px;
-              border-top: 1px solid #e2e8f0;
-            }
-            .people-label {
-              font-weight: 600;
-              color: #64748b;
-              margin-right: 8px;
-              font-size: 14px;
-            }
-            .person {
-              display: inline-block;
-              background-color: rgba(92, 124, 250, 0.1);
-              color: #4263eb;
-              padding: 4px 8px;
-              border-radius: 4px;
-              font-size: 12px;
-              margin-right: 6px;
-              margin-bottom: 6px;
-              font-weight: 500;
-              border: 1px solid rgba(92, 124, 250, 0.2);
-            }
             .chat-button-container {
               margin-top: 16px;
               text-align: center;
@@ -325,7 +297,6 @@ async function sendEmail(data: EmailData): Promise<boolean> {
       groupedSummaries[channelId].forEach(summary => {
         const formattedDate = formatDate(summary.content_created_at || summary.created_at);
         const summaryHtml = markdownToHtml(summary.summary);
-        const people = summary.featured_names || [];
         const titleLink = summary.source_url ? 
           `<a href="${summary.source_url}" target="_blank">${summary.title || 'Untitled Summary'}</a>` : 
           `${summary.title || 'Untitled Summary'}`;
@@ -347,14 +318,6 @@ async function sendEmail(data: EmailData): Promise<boolean> {
               </div>
         `;
 
-        if (people.length > 0) {
-          htmlContent += `
-            <div class="people-section">
-              <span class="people-label">People:</span>
-              ${people.map(person => `<span class="person">${person}</span>`).join('')}
-            </div>
-          `;
-        }
 
         // Add the Chat with Video button with Outlook VML support
         htmlContent += `
@@ -575,7 +538,7 @@ async function handleRequest(req: Request) {
         // Get new summaries from subscribed channels - now including source_url
         const { data: summaries, error: summariesError } = await supabase
           .from("summaries")
-          .select("id, content_id, title, publisher_id, publisher_name, summary, content_created_at, created_at, tags, featured_names, source_url")
+          .select("id, content_id, title, publisher_id, publisher_name, summary, content_created_at, created_at, source_url")
           .in("publisher_id", channelIds)
           .gt("content_created_at", cutoffDate.toISOString())
           .order("content_created_at", { ascending: false });


### PR DESCRIPTION
## Summary
- drop tag and people props from `SummaryCard`
- simplify summary interfaces
- trim AI responses instead of parsing tags/people
- update prompt to return only the summary text
- use `o3` model in API routes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848949fbec88324a12b4966c2726ebd